### PR TITLE
add -f to rm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ deploy-client:
 deploy-service: deploy-scripts
 	cp $(DIR)/service/jetty.xml $(SERVICE_DIR)/
 	mkdir -p $(SERVICE_DIR)/webapps
-	rm $(SERVICE_DIR)/webapps/*.war
+	rm -f $(SERVICE_DIR)/webapps/*.war
 	cp $(DIR)/dist/$(SERVICE_NAME).war $(SERVICE_DIR)/webapps/root.war
 	cp $(DIR)/deploy.cfg $(SERVICE_DIR)/
 	echo '#!/bin/bash' > $(SERVICE_DIR)/start_service


### PR DESCRIPTION
For clean deploys, there aren't yet any war files in $deployment/webapps, and rm returns a nonzero exit code.  Add -f to ignore missing files so rm exits cleanly.
